### PR TITLE
Empty login data caused logins to fail.

### DIFF
--- a/Controller/Component/Auth/CookieAuthenticate.php
+++ b/Controller/Component/Auth/CookieAuthenticate.php
@@ -43,17 +43,21 @@ class CookieAuthenticate extends BaseAuthenticate {
 
 		list(, $model) = pluginSplit($this->settings['userModel']);
 
-		$data = $this->_Collection->Cookie->read($model);
+		$data = array(
+			'username' => $request->data('User.username'),
+			'password' => $request->data('User.password')
+		);
+
 		if (empty($data)) {
 			return false;
 		}
 
 		extract($this->settings['fields']);
-		if (empty($data[$username]) || empty($data[$password])) {
+		if (empty($data['username']) || empty($data['password'])) {
 			return false;
 		}
 
-		return $this->_findUser($data[$username], $data[$password]);
+		return $this->_findUser($data['username'], $data['password']);
 	}
 
 }


### PR DESCRIPTION
Prior to this commit AuthComponent::login() kept returning false
and thus made every login attempt fail.

Turned out the $data variable in the modified file has always
been empty. This variable is now filled with CakeRequest's data
(the form submission data).

The login itself works. The cookie hasn't been tested yet.
