### PR TITLE
making travis setup more generic

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-src_dir: plugins/Authenticate
-coverage_clover: build/logs/clover.xml
-json_path: build/logs/coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ php:
   - 5.5
 
 env:
-  - CAKE_VERSION=master DB=mysql
-  - CAKE_VERSION=master DB=pgsql
-  - CAKE_VERSION=2.5 DB=mysql
-  - CAKE_VERSION=2.5 DB=pgsql
+  global:
+    - REPO_NAME=Authenticate
+    - PLUGIN_NAME=Authenticate
+  matrix:
+    - CAKE_VERSION=master DB=mysql
+    - CAKE_VERSION=master DB=pgsql
+    - CAKE_VERSION=2.5 DB=mysql
+    - CAKE_VERSION=2.5 DB=pgsql
 
 matrix:
   include:
@@ -21,75 +25,14 @@ matrix:
         - DB=mysql CAKE_VERSION=master PHPCS=1
 
 before_script:
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
-  - git clone git://github.com/cakephp/cakephp ../cakephp && cd ../cakephp && git checkout $CAKE_VERSION
-  - cp -R ../Authenticate plugins/Authenticate
-  - chmod -R 777 ../cakephp/app/tmp
-  - sh -c "if [ '$PHPCS' = '1' ]; then pear channel-discover pear.cakephp.org; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then pear install --alldeps cakephp/CakePHP_CodeSniffer; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer install --dev --no-interaction --prefer-source; fi"
-  - phpenv rehash
-  - set +H
-  - echo "<?php
-    class DATABASE_CONFIG {
-    private \$identities = array(
-      'mysql' => array(
-        'datasource' => 'Database/Mysql',
-        'host' => '0.0.0.0',
-        'login' => 'travis'
-      ),
-      'pgsql' => array(
-        'datasource' => 'Database/Postgres',
-        'host' => '127.0.0.1',
-        'login' => 'postgres',
-        'database' => 'cakephp_test',
-        'schema' => array(
-          'default' => 'public',
-          'test' => 'public'
-        )
-      )
-    );
-    public \$default = array(
-      'persistent' => false,
-      'host' => '',
-      'login' => '',
-      'password' => '',
-      'database' => 'cakephp_test',
-      'prefix' => ''
-    );
-    public \$test = array(
-      'persistent' => false,
-      'host' => '',
-      'login' => '',
-      'password' => '',
-      'database' => 'cakephp_test',
-      'prefix' => ''
-    );
-    public function __construct() {
-      \$db = 'mysql';
-      if (!empty(\$_SERVER['DB'])) {
-        \$db = \$_SERVER['DB'];
-      }
-      foreach (array('default', 'test') as \$source) {
-        \$config = array_merge(\$this->{\$source}, \$this->identities[\$db]);
-        if (is_array(\$config['database'])) {
-          \$config['database'] = \$config['database'][\$source];
-        }
-        if (!empty(\$config['schema']) && is_array(\$config['schema'])) {
-          \$config['schema'] = \$config['schema'][\$source];
-        }
-        \$this->{\$source} = \$config;
-      }
-    }
-    }" > ../cakephp/app/Config/database.php
+  - ./travis.sh
+  - cd ../cakephp
 
 script:
-  - sh -c "if [ '$PHPCS' != '1' ]; then ./lib/Cake/Console/cake test Authenticate AllAuthenticate --stderr --coverage-clover build/logs/clover.xml; else phpcs -p --extensions=php --standard=CakePHP ./plugins/Authenticate/Controller; fi"
+  - ./lib/Cake/Console/cake test $PLUGIN_NAME All$PLUGIN_NAME --stderr --coverage-clover build/logs/clover.xml
 
-after_script:
-  - sh -c "if [ '$COVERALLS' = '1' ]; then cp plugins/Authenticate/.coveralls.yml . ; php vendor/bin/coveralls -c .coveralls.yml -v; fi"
+after_success:
+  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
 
 notifications:
   email: false

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+if [ "$DB" = "mysql" ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi
+if [ "$DB" = "pgsql" ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
+
+cd ..
+git clone git://github.com/cakephp/cakephp.git --branch $CAKE_VERSION --depth 1
+cd cakephp
+
+if [ "$COVERALLS" = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi
+if [ "$COVERALLS" = '1' ]; then composer install --dev --no-interaction --prefer-source; fi
+
+if [ "$PHPCS" = '1' ]; then pear channel-discover pear.cakephp.org; fi
+if [ "$PHPCS" = '1' ]; then pear install --alldeps cakephp/CakePHP_CodeSniffer; fi
+
+phpenv rehash
+
+cp -R ../$REPO_NAME plugins/$PLUGIN_NAME
+chmod -R 777 app/tmp
+
+set +H
+echo "<?php
+    class DATABASE_CONFIG {
+    private \$identities = array(
+      'mysql' => array(
+        'datasource' => 'Database/Mysql',
+        'host' => '0.0.0.0',
+        'login' => 'travis'
+      ),
+      'pgsql' => array(
+        'datasource' => 'Database/Postgres',
+        'host' => '127.0.0.1',
+        'login' => 'postgres',
+        'database' => 'cakephp_test',
+        'schema' => array(
+          'default' => 'public',
+          'test' => 'public'
+        )
+      )
+    );
+    public \$default = array(
+      'persistent' => false,
+      'host' => '',
+      'login' => '',
+      'password' => '',
+      'database' => 'cakephp_test',
+      'prefix' => ''
+    );
+    public \$test = array(
+      'persistent' => false,
+      'host' => '',
+      'login' => '',
+      'password' => '',
+      'database' => 'cakephp_test',
+      'prefix' => ''
+    );
+    public function __construct() {
+      \$db = 'mysql';
+      if (!empty(\$_SERVER['DB'])) {
+        \$db = \$_SERVER['DB'];
+      }
+      foreach (array('default', 'test') as \$source) {
+        \$config = array_merge(\$this->{\$source}, \$this->identities[\$db]);
+        if (is_array(\$config['database'])) {
+          \$config['database'] = \$config['database'][\$source];
+        }
+        if (!empty(\$config['schema']) && is_array(\$config['schema'])) {
+          \$config['schema'] = \$config['schema'][\$source];
+        }
+        \$this->{\$source} = \$config;
+      }
+    }
+}" > app/Config/database.php
+
+echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<phpunit>
+<filter>
+    <whitelist>
+        <directory suffix=\".php\">plugins/$PLUGIN_NAME</directory>
+        <exclude>
+            <directory suffix=\".php\">plugins/$PLUGIN_NAME/Test</directory>
+        </exclude>
+    </whitelist>
+</filter>
+</phpunit>" > phpunit.xml
+
+echo "# for php-coveralls
+src_dir: plugins/$PLUGIN_NAME
+coverage_clover: build/logs/clover.xml
+json_path: build/logs/coveralls-upload.json" > .coveralls.yml


### PR DESCRIPTION
Let travis use a standard script, which can be reused in any plugin.

Required steps for reuse:
- Put this travis.sh in the root of your plugin
- Put this .travis.yml in the root of your plugin
- update REPO_NAME, to match the github repo name
- update PLUGIN_NAME to match CamelCased plugin naming for CakePHP
- ensure the plugin has an All{PluginNameHere}Test.php
