### PR TITLE
Fixes authenticate()

### DIFF
--- a/Controller/Component/Auth/TokenAuthenticate.php
+++ b/Controller/Component/Auth/TokenAuthenticate.php
@@ -84,7 +84,7 @@ class TokenAuthenticate extends BaseAuthenticate {
  * @return boolean Always false.
  */
 	public function authenticate(CakeRequest $request, CakeResponse $response) {
-		return false;
+		return $this->getUser($request);
 	}
 
 /**


### PR DESCRIPTION
AuthComponent::identify() and AuthComponent::login() go through the authenticate function, if false is returned, getUSer() would never be run and the plugin wouldn't work.

To make the stateless authentication work I personally use $this->Auth->identify(), otherwise $this->Auth->login() creates a session.
