### PR TITLE
Remove unused settings from Cookie adapter

### DIFF
--- a/Controller/Component/Auth/CookieAuthenticate.php
+++ b/Controller/Component/Auth/CookieAuthenticate.php
@@ -1,7 +1,6 @@
 <?php
 App::uses('BaseAuthenticate', 'Controller/Component/Auth');
 App::uses('AuthComponent', 'Controller/Component');
-App::uses('Router', 'Routing');
 
 /**
  * An authentication adapter for AuthComponent
@@ -18,10 +17,6 @@ App::uses('Router', 'Routing');
  *			'userModel' => 'User',
  *			'scope' => array('User.active' => 1),
  *			'crypt' => 'rijndael', // Defaults to rijndael(safest), optionally set to 'cipher' if required
- *			'cookie' => array(
- *				'name' => 'RememberMe',
- *				'time' => '+2 weeks',
- *			)
  *		)
  *	)
  * }}}
@@ -32,11 +27,6 @@ App::uses('Router', 'Routing');
 class CookieAuthenticate extends BaseAuthenticate {
 
 	public function __construct(ComponentCollection $collection, $settings) {
-		$this->settings['cookie'] = array(
-			'name' => 'RememberMe',
-			'time' => '+2 weeks',
-			'base' => Router::getRequest()->base
-		);
 		$this->settings['crypt'] = 'rijndael';
 		parent::__construct($collection, $settings);
 	}


### PR DESCRIPTION
These cookie-related settings seem unnecessary here and a bit confusing.

Introduced in https://github.com/FriendsOfCake/Authenticate/commit/8188510a9f2db0cd0bfdf17b445c778108081e5d