### PR TITLE
Update composer config to install plugin under FOC/Authenticate.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,8 @@
             "FOC\\Authenticate\\": "src",
             "FOC\\Authenticate\\Test\\": "tests"
         }
+    },
+    "extra": {
+        "installer-name": "FOC/Authenticate"
     }
 }


### PR DESCRIPTION
This fixes the problem where the plugin was installed under `plugins/Authenticate` instead of `plugins/FOC/Authenticate` so that `Plugin::load('FOC/Authenticate')` can work as expected.
