### PR TITLE
Fix Fatal error: Class 'BadRequestException' not found

### DIFF
--- a/src/Auth/TokenAuthenticate.php
+++ b/src/Auth/TokenAuthenticate.php
@@ -63,7 +63,7 @@ class TokenAuthenticate extends BaseAuthenticate {
 			'header' => 'X-ApiToken',
 			'fields' => ['token' => 'token', 'password' => 'password'],
 			'continue' => false,
-			'unauthorized' => 'BadRequestException'
+			'unauthorized' => 'Cake\Network\Exception\BadRequestException'
 		]);
 
 		$this->config($config);


### PR DESCRIPTION
When using the TokenAuthentication without `'continue' => true`, we got the following error:

`Fatal error: Class 'BadRequestException' not found in /vendor/friendsofcake/authenticate/src/Auth/TokenAuthenticate.php on line 106`

Here's a patch to fix that